### PR TITLE
Replace Mersenne-Twister pseudo random generator by xorshift

### DIFF
--- a/RT_SYCL/main.cpp
+++ b/RT_SYCL/main.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <iterator>
 #include <math.h>
-#include <random>
 #include <thread>
 #include <vector>
 

--- a/RT_SYCL/rtweekend.hpp
+++ b/RT_SYCL/rtweekend.hpp
@@ -10,9 +10,14 @@
 #include <variant>
 #include <vector>
 
+#include <triSYCL/vendor/trisycl/random/xorshift.hpp>
+
+/// \todo Remove these global objects and move them into the kernel.
+/// It cannot work with SYCL on device otherwise.
 namespace {
 std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
-std::mt19937 generator;
+/// A fast random generator good on accelerator like FPGA
+trisycl::vendor::trisycl::random::xorshift generator;
 }
 
 // Constants

--- a/RT_SYCL/rtweekend.hpp
+++ b/RT_SYCL/rtweekend.hpp
@@ -10,7 +10,7 @@
 #include <variant>
 #include <vector>
 
-#include <triSYCL/vendor/trisycl/random/xorshift.hpp>
+#include <triSYCL/vendor/triSYCL/random/xorshift.hpp>
 
 /// \todo Remove these global objects and move them into the kernel.
 /// It cannot work with SYCL on device otherwise.


### PR DESCRIPTION
The xorshift pseudo random generator from the triSYCL extension
reduces execution time by something like -25% on my laptop (+1/3
speedup) while still to be random enough for such a graphic
application.